### PR TITLE
Fix link to 'Git Reference Sheet'

### DIFF
--- a/syllabus/index.html
+++ b/syllabus/index.html
@@ -57,7 +57,7 @@
 <li><a href="git-03-conflict.html">Conflicts</a></li>
 <li><a href="git-04-open.html">Open science</a></li>
 </ol>
-<p><a href="git_reference.md"><strong>Git Reference Sheet</strong></a></p>
+<p><a href="git_reference.html"><strong>Git Reference Sheet</strong></a></p>
 <h3 id="r-day-2">R (day 2)</h3>
 <p><em>Download the (same) data for the R lessons here:</em> <a href="./data/gapminder-FiveYearData.csv"><code>gapminder-FiveYearData.csv</code></a></p>
 <ol style="list-style-type: decimal">

--- a/syllabus/index.md
+++ b/syllabus/index.md
@@ -41,7 +41,7 @@ Remember that additional notes, links, etc. will be found on [the Etherpad](http
 4. [Conflicts](git-03-conflict.html)
 5. [Open science](git-04-open.html)
 
-[**Git Reference Sheet**](git_reference.md)
+[**Git Reference Sheet**](git_reference.html)
 
 ### R (day 2)
 


### PR DESCRIPTION
Link points to a markdown file and 404s.
